### PR TITLE
Won't switch tasks that don't have matching done attribute.

### DIFF
--- a/app/src/main/java/org/mam/kch/fyreagenda/RecyclerListAdapter.java
+++ b/app/src/main/java/org/mam/kch/fyreagenda/RecyclerListAdapter.java
@@ -178,6 +178,9 @@ public class RecyclerListAdapter extends RecyclerView.Adapter<RecyclerListAdapte
 
     @Override
     public boolean onItemMove(int fromPosition, int toPosition) {
+        if(mValues.get(fromPosition).getTaskComplete() != mValues.get(toPosition).getTaskComplete()){
+            return false;
+        }
         Collections.swap(mValues, fromPosition, toPosition);
         Task.updatePositions(mValues.get(0).getTaskType());
 


### PR DESCRIPTION
Just some quick testing locally. Seems to prevent tasks from getting checked / unchecked by preventing switching them.